### PR TITLE
feat: add extra_text_objects option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ if the defaults are okay:
 
 ```lua
 require('leap-spooky').setup {
+  -- Additional text objects, to be merged with the default ones.
+  -- E.g.: {'iq', 'aq'}
+  extra_text_objects = nil
   -- Mappings will be generated corresponding to all native text objects,
   -- like: (ir|ar|iR|aR|im|am|iM|aM){obj}.
   -- Special line objects will also be added, by repeating the affixes.
@@ -66,7 +69,8 @@ require('leap-spooky').setup {
     remote = { window = 'r', cross_window = 'R' },
   },
   -- Defines text objects like `riw`, `raw`, etc., instead of
-  -- targets.vim-style `irw`, `arw`.
+  -- targets.vim-style `irw`, `arw`. (Note: prefix is forced if a custom
+  -- text object does not start with "a" or "i".)
   prefix = false,
   -- The yanked text will automatically be pasted at the cursor position
   -- if the unnamed register is in use.
@@ -114,5 +118,3 @@ You can also check the source code for ideas, or if something is unclear.
 - Label the text objects themselves (at least blocks, paragraphs, etc.), so that
   you can immediately choose one, instead of having to specify the reference
   point with a default 2-char Leap motion.
-
-- API for "spookifying" custom (non-native) text objects.

--- a/lua/leap-spooky.lua
+++ b/lua/leap-spooky.lua
@@ -80,10 +80,13 @@ local function setup(kwargs)
   local kwargs = kwargs or {}
   local affixes = kwargs.affixes
   local yank_paste = kwargs.paste_on_remote_yank or kwargs.yank_paste
+  local extra_text_objects = kwargs.extra_text_objects or {}
 
   local default_register = (vim.o.clipboard == 'unnamed' and "*" or
                             vim.o.clipboard:match('unnamedplus') and "+" or
                             "\"")
+
+  local text_objects = vim.tbl_extend('force', default_text_objects, extra_text_objects)
 
   local v_exit = function()
     local mode = vim.fn.mode(1)
@@ -96,7 +99,7 @@ local function setup(kwargs)
   for kind, scopes in pairs(affixes or default_affixes) do
     local keeppos = kind == 'remote'
     for scope, key in pairs(scopes) do
-      for _, textobj in ipairs(default_text_objects) do
+      for _, textobj in ipairs(text_objects) do
         table.insert(mappings, {
           scope = scope,
           keeppos = keeppos,

--- a/lua/leap-spooky.lua
+++ b/lua/leap-spooky.lua
@@ -103,8 +103,10 @@ local function setup(kwargs)
         table.insert(mappings, {
           scope = scope,
           keeppos = keeppos,
-          lhs = (kwargs.prefix and key .. textobj
-                               or textobj:sub(1,1) .. key .. textobj:sub(2)),
+          -- Force prefix if a custom textobject does not follow the a/i pattern.
+          lhs = (kwargs.prefix or not textobj:sub(1,1):match('[aiAI]')
+                 and key .. textobj
+                 or textobj:sub(1,1) .. key .. textobj:sub(2)),
           action = function ()
             return v_exit() .. "v" .. vim.v.count1 .. textobj .. get_motion_force()
           end,


### PR DESCRIPTION
Add a new optional config option `extra_text_objects` which is merged with `default_text_objects`. 

The use case is to allow users to configure third-party text-object mappings they've declared somewhere else. For example I'm adding my own treesitter text-objects and the any quote (`q`) from `targets.vim`.

Tested with following config:

```lua
      require("leap-spooky").setup {
        extra_text_objects = {
          "iq", "aq",
          "iv", "av",
          "ik", "ak",
        },
```