### PR TITLE
fix: always assign string in lhs mapping ternary

### DIFF
--- a/lua/leap-spooky.lua
+++ b/lua/leap-spooky.lua
@@ -99,9 +99,11 @@ local function setup(kwargs)
           scope = scope,
           keeppos = keeppos,
           -- Force prefix if a custom textobject does not follow the a/i pattern.
-          lhs = (kwargs.prefix or not textobj:sub(1,1):match('[aiAI]')
-                 and key .. textobj
-                 or textobj:sub(1,1) .. key .. textobj:sub(2)),
+          lhs = (
+            (kwargs.prefix or not textobj:sub(1,1):match('[aiAI]'))
+            and key .. textobj
+            or textobj:sub(1,1) .. key .. textobj:sub(2)
+          ),
           select_cmd = function ()
             return v_exit() .. "v" .. vim.v.count1 .. textobj .. get_motion_force()
           end,


### PR DESCRIPTION
Hello! `prefix = true` in config results in the following error:

```
Failed to run `config` for leap-spooky.nvim

vim/keymap.lua:39: lhs: expected string, got boolean

# stacktrace:
  - vim/shared.lua:842 _in_ **validate**
  - vim/keymap.lua:39 _in_ **set**
  - /leap-spooky.nvim/lua/leap-spooky.lua:129 _in_ **setup**
```

Since 0ecd057 it appears that line the lhs assignment was being assigned to `true` if `kwargs.prefix == true`, due to the way the operands were distributed. This PR changes the lhs assignment to be closer to the previous expression. If this is correct and not an issue with my config, please make any preferred style changes. Thank you!

<details>
<summary>overview of changes</summary>

previous 808bd88 
```lua
          lhs = (kwargs.prefix and key .. textobj
                               or textobj:sub(1,1) .. key .. textobj:sub(2)),
```

current 0ecd057
```lua
          lhs = (kwargs.prefix or not textobj:sub(1,1):match('[aiAI]')
                 and key .. textobj
                 or textobj:sub(1,1) .. key .. textobj:sub(2)),
```

proposed
```lua
          lhs = (
            (kwargs.prefix or not textobj:sub(1,1):match('[aiAI]'))
            and key .. textobj
            or textobj:sub(1,1) .. key .. textobj:sub(2)
          ),
```

</details>